### PR TITLE
Add comment why cli is used

### DIFF
--- a/src/repo_example/cli.py
+++ b/src/repo_example/cli.py
@@ -1,6 +1,5 @@
 """Console script for repo_example."""
 import sys
-import sys
 import click
 
 


### PR DESCRIPTION
addition information why this needed 
```python
d = {'a': 1}
```